### PR TITLE
feature : generate IPv6 addresses for a given network range

### DIFF
--- a/include/survery6_active/scan.h
+++ b/include/survery6_active/scan.h
@@ -1,7 +1,24 @@
 #include <string>
+#include <boost/asio.hpp>
+
+using namespace boost::asio;
 using namespace std;
 #ifndef SCAN_H
 #define SCAN_H
+
+
+/**
+ * Usage:
+* This utility generates the ip addresses in the given network address range for scan purposes
+*
+* arguments
+* network_range string     The IPv6 CIDR range to scan.
+
+*/
+
+ip::address_v6_range generate_ip_addresses(string network_range);
+
+
 
 /**
  * Usage:

--- a/src/scan.cpp
+++ b/src/scan.cpp
@@ -1,14 +1,30 @@
 #include <iostream>
 #include <survery6_active/scan.h>
 
+ip::address_v6_range generate_ip_addresses(string network_range){
+    boost::system::error_code error_code;
+    ip::network_v6 subnet = ip::make_network_v6(network_range,error_code);
+    if(error_code)
+    {
+        std::cerr << "Error in the network range argument: " <<error_code.message() << "\n";
+    }
+    ip::address_v6_range hosts = subnet.hosts();
+
+    return hosts;
+}
+
 // TODO:
-// generates candidate addresses
 // scans for them
 // tests the network ranges where live addresses are found for aliased conditions
 // add legitimate discovered IPv6 addresses to an output list
-
 void scan(string network)
 {
     cout << "Scanning networking rage " << network << endl;
+    ip::address_v6_range hosts= generate_ip_addresses(network);
+    for (auto addrs: hosts){
+        string ip6 = addrs.to_string();
+        cout << ip6 <<endl;
+    }
     cout << "Scan completed" << endl;
+
 }


### PR DESCRIPTION
# Description

Create a function to generate the list of all the Ipv6 addresses for a given network address range in the CIDR format. 

Dependency: boost 

Fixes #3 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Manually tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
